### PR TITLE
Article VII:4 and VII:5

### DIFF
--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -336,6 +336,10 @@ This requires the [Participation Fees](https://github.com/open-contracting-exten
         <td markdown=1>
 
 * Enter the *evaluation criteria set out in the notice of intended procurement or tender documentation* in `tender/awardCriteriaDetails`
+* If the *evaluation criteria* are published as a document:
+ * Add a `Document` object to the `tender/documents` array
+ * Set its `documentType` to 'evaluationCriteria'
+
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -150,7 +150,10 @@ This requires the [Additional Contact Points](https://github.com/open-contractin
         <td>a list and brief description of any conditions for participation of suppliers, including any requirements for specific documents or certifications to be provided by suppliers in connection therewith, unless such requirements are included in tender documentation that is made available to all interested suppliers at the same time as the notice of intended procurement;</td>
         <td markdown=1>
 
-* Add this to `tender/eligibilityCriteria`
+* Add *a list and brief description of any conditions for participation of suppliers* to `tender/eligibilityCriteria`
+* If *requirements are included in tender documentation that is made available to all interested suppliers*:
+  * For each document, add a `Document` object to the `tender/documents` array
+  * Set its `documentType` to 'eligibilityCriteria'
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -171,7 +171,7 @@ This requires the [Second Stage](https://github.com/open-contracting-extensions/
 
 This requires the [Selection Criteria](https://github.com/open-contracting-extensions/ocds_selectionCriteria_extension) extension.
 
-* If *the criteria that will be used to select them* are published as documents:
+* If *the criteria that will be used to select [the suppliers]* are published as documents:
   * For each document, add a `Document` object to the `tender/documents` array
   * Set its `documentType` to 'selectionCriteria'
   * Fill any other known information for the document ([`Document` object schema](https://standard.open-contracting.org/1.1/en/schema/reference/#document))

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -229,7 +229,7 @@ This requires the [Communication](https://github.com/open-contracting-extensions
         <td>A procuring entity covered under Annex 2 or 3 may use a notice of planned procurement as a notice of intended procurement provided that the notice of planned procurement includes as much of the information referred to in paragraph 2 as is available to the entity and a statement that interested suppliers should express their interest in the procurement to the procuring entity.</td>
         <td markdown=1>
 
-* Follow the guidance for article VII:2.
+* Follow the guidance for VII:2.
 </td>
       </tr>
     </tbody>
@@ -259,8 +259,8 @@ This requires the [Communication](https://github.com/open-contracting-extensions
         <td>the procurement, including the nature and the quantity of the goods or services to be procured or, where the quantity is not known, the estimated quantity and any requirements to be fulfilled, including any technical specifications, conformity assessment certification, plans, drawings or instructional materials;</td>
         <td markdown=1>
 
-* For *the procurement, including the nature and the quantity of the goods or services to be procured or, where the quantity is not known, the estimated quantity*, follow the guidance for article VII:2(b)
-* For *any requirements to be fulfilled, including any technical specifications, conformity assessment certification, plans, drawings or instructional materials*, follow the guidance for article VII:2(j)
+* For *the procurement, including the nature and the quantity of the goods or services to be procured or, where the quantity is not known, the estimated quantity*, follow the guidance for VII:2(b)
+* For *any requirements to be fulfilled, including any technical specifications, conformity assessment certification, plans, drawings or instructional materials*, follow the guidance for VII:2(j)
 </td>
       </tr>
       <tr>
@@ -333,7 +333,7 @@ This requires the [Participation Fees](https://github.com/open-contracting-exten
         <td>any dates for the delivery of goods or the supply of services</td>
         <td markdown=1>
 
-* Follow the guidance for article VII:2(e)
+* Follow the guidance for VII:2(e)
 </td>
       </tr>
       <tr>
@@ -358,9 +358,9 @@ This requires the [Participation Fees](https://github.com/open-contracting-exten
         <td markdown=1>
 
 * Create a new OCDS release and follow the corresponding guidance, depending on the information that has been modified:
-  * If the *the criteria or requirements* are modified, follow the guidance for article X:9
+  * If the *the criteria or requirements* are modified, follow the guidance for X:9
   * If *a notice* (of intended procurement) is amended or reissued, follow the guidance of article VII:2
-  * If the *tender documentation* is amended or reissued, follow the guidance for article X:7
+  * If the *tender documentation* is amended or reissued, follow the guidance for X:7
 
 </td>
       </tr>
@@ -387,7 +387,7 @@ This requires the [Participation Fees](https://github.com/open-contracting-exten
         <td>A procuring entity shall prepare a report in writing on each contract awarded under paragraph 1. The report shall include the name of the procuring entity, the value and kind of goods or services procured and a statement indicating the circumstances and conditions described in paragraph 1 that justified the use of limited tendering.</td>
         <td markdown=1>
 
-* If the following data has not been published following the guidance for article VII:2
+* If the following data has not been published following the guidance for VII:2
   * For *the name of the procuring entity*, follow the guidance for VII:2(a)
   * For the *kind of goods or services procured*, follow the guidance for VII:2(b)
 * Add an `Award` object to the `awards` array

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -11,7 +11,7 @@ This document annotates selected parts of the GPA, with details on how to publis
 ```eval_rst
 .. warning::
 
-   References from Articles IX:8, IX:9, X:7, X:9, X:11, XIII:2, XIV:1, XVI:2 are not yet added.
+   References from Articles VII:4, VII:5, IX:8, IX:9, X:7, X:9, X:11, XIII:2, XIV:1, XVI:2 are not yet added.
 ```
 
 <div class="wy-table-responsive">
@@ -207,7 +207,6 @@ If at the time of publishing a notice of planned procurement (article VII:4) you
     </tbody>
   </table>
 
-<!--
   <table class="docutils">
     <caption><a href="https://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm#articleX">Article X</a> Notices</caption>
     <colgroup>
@@ -225,71 +224,13 @@ If at the time of publishing a notice of planned procurement (article VII:4) you
     <tbody>
       <tr class="section">
         <td>X:7</td>
-        <td colspan="2">A procuring entity shall make available to suppliers tender documentation that includes all information necessary to permit suppliers to prepare and submit responsive tenders. Unless already provided in the notice of intended procurement, such documentation shall include a complete description of:</td>
-      </tr>
-      <tr>
-        <td>X:7(a)</td>
-        <td>the procurement, including the nature and the quantity of the goods or services to be procured or, where the quantity is not known, the estimated quantity and any requirements to be fulfilled, including any technical specifications, conformity assessment certification, plans, drawings or instructional materials;</td>
+        <td>A procuring entity shall make available to suppliers tender documentation that includes all information necessary to permit suppliers to prepare and submit responsive tenders. Unless already provided in the notice of intended procurement, such documentation shall include a complete description of:</td>
         <td markdown=1>
 
-* 
-</td>
-      </tr>
-      <tr>
-        <td>X:7(b)</td>
-        <td>any conditions for participation of suppliers, including a list of information and documents that suppliers are required to submit in connection with the conditions for participation;</td>
-        <td markdown=1>
+If at the time of publishing tender documentation (article X:7) you have already published all the information necessary for a notice of intended procurement (article VII:2), and this information has not changed, discard this article.
 
-* 
-</td>
-      </tr>
-      <tr>
-        <td>X:7(c)</td>
-        <td>all evaluation criteria the entity will apply in the awarding of the contract, and, except where price is the sole criterion, the relative importance of such criteria;</td>
-        <td markdown=1>
-
-* 
-</td>
-      </tr>
-      <tr>
-        <td>X:7(d)</td>
-        <td>where the procuring entity will conduct the procurement by electronic means, any authentication and encryption requirements or other requirements related to the submission of information by electronic means;</td>
-        <td markdown=1>
-
-* 
-</td>
-      </tr>
-      <tr>
-        <td>X:7(e)</td>
-        <td>where the procuring entity will hold an electronic auction, the rules, including identification of the elements of the tender related to the evaluation criteria, on which the auction will be conducted;</td>
-        <td markdown=1>
-
-* 
-</td>
-      </tr>
-      <tr>
-        <td>X:7(f)</td>
-        <td>where there will be a public opening of tenders, the date, time and place for the opening and, where appropriate, the persons authorized to be present;</td>
-        <td markdown=1>
-
-* 
-</td>
-      </tr>
-      <tr>
-        <td>X:7(g)</td>
-        <td>any other terms or conditions, including terms of payment and any limitation on the means by which tenders may be submitted, such as whether on paper or by electronic means; and</td>
-        <td markdown=1>
-
-* 
-</td>
-      </tr>
-      <tr>
-        <td>X:7(h)</td>
-        <td>any dates for the delivery of goods or the supply of services</td>
-        <td markdown=1>
-
-* 
-</td>
+If you haven't published all the information necessary for a notice of intended procurement or if the information has changed, follow the guidance for article VII:2 to publish the new and updated data.
+        </td>
       </tr>
       <tr>
         <td>X:9</td>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -276,7 +276,7 @@ This requires the [Communication](https://github.com/open-contracting-extensions
         <td>all evaluation criteria the entity will apply in the awarding of the contract, and, except where price is the sole criterion, the relative importance of such criteria;</td>
         <td markdown=1>
 
-* Follow the guidance for VII:(k)
+* Follow the guidance for VII:2(k)
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -319,7 +319,7 @@ This requires the [Participation Fees](https://github.com/open-contracting-exten
 
 * Enter *the means by which tenders may be submitted* in `tender/submissionMethod`
   * If it's on *paper*, enter 'written'
-  * If it's 'electronic', enter 'electronicSubmission'
+  * If it's *electronic*, enter 'electronicSubmission'
 </td>
       </tr>
       <tr>
@@ -381,7 +381,18 @@ This requires the [Participation Fees](https://github.com/open-contracting-exten
         <td>A procuring entity shall prepare a report in writing on each contract awarded under paragraph 1. The report shall include the name of the procuring entity, the value and kind of goods or services procured and a statement indicating the circumstances and conditions described in paragraph 1 that justified the use of limited tendering.</td>
         <td markdown=1>
 
-* 
+* If the following data has not been published following the guidance for article VII:2
+  * For *the name of the procuring entity*, follow the guidance for VII:2(a)
+  * For the *kind of goods or services procured*, follow the guidance for VII:2(b)
+* Add an `Award` object to the `awards` array
+  * Enter an identifier in its `id`, which can be arbitrary as it is primarily to allow referencing   from other parts of the file
+  * Enter *the value [of the goods or services]* in its `value/amount`
+  * Enter the currency in `value/currency` (see the [currency](https://standard.open-contracting.org/latest/en/schema/codelists/#currency) codelist)
+* Enter *the circumstances and conditions described in paragraph 1  that justified the use of limited tendering* in `tender/procurementMethodRationale`
+* If the *report in writing* is also published as a document
+  * Add a `Document` object to the `tender/documents` array
+  * Set its `documentType` to 'awardNotice'
+
 </td>
       </tr>
     </tbody>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -109,7 +109,9 @@ The addition of `period` to the `Milestone` building block is [under discussion]
 
 * Use 'open', 'selective' or 'limited' for *the procurement method that will be used* in `tender/procurementMethod`
 * If *it will involve negotiation*, add "negotiated" to `tender/procurementMethodDetails`
-* If *it will involve electronic auction* set `tender/techniques/hasElectronicAuction` to `true`
+* If *it will involve electronic auction*
+  * set `tender/submissionMethod` to `electronicAuction`
+  * set `tender/techniques/hasElectronicAuction` to `true`
 
 This requires the [Techniques](https://github.com/open-contracting-extensions/ocds_techniques_extension) extension.
 </td>
@@ -205,9 +207,7 @@ The information included in the notice of intended procurement covers all the in
 * Add 'planning' to the `tag` array
 * Set `tender/status` to 'planning'
 * Enter *the subject-matter of the procurement* in `tender/description`. The value of `tender/description` can be updated when the data described in article VII:2(b) is published.
-* Enter *the planned date of the publication of the notice of intended procurement* in `tender/communication/futureNoticeDate`
-
-This requires the [Communication](https://github.com/open-contracting-extensions/ocds_communication_extension) extension.
+* Enter *the planned date of the publication of the notice of intended procurement* in `tender/tenderPeriod/startDate`
 </td>
       </tr>
       <tr>
@@ -254,7 +254,7 @@ This requires the [Communication](https://github.com/open-contracting-extensions
         <td>any conditions for participation of suppliers, including a list of information and documents that suppliers are required to submit in connection with the conditions for participation;</td>
         <td markdown=1>
 
-* Please follow the guidance for VII:2(j)
+* Please follow the guidance for VII:(j)
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -254,7 +254,7 @@ This requires the [Communication](https://github.com/open-contracting-extensions
     <tbody>
       <tr class="section">
         <td>X:7</td>
-        <td colspan=2>A procuring entity shall make available to suppliers tender documentation that includes all information necessary to permit suppliers to prepare and submit responsive tenders. Unless already provided in the notice of intended procurement, such documentation shall include a complete description of:</td>
+        <td colspan="2">A procuring entity shall make available to suppliers tender documentation that includes all information necessary to permit suppliers to prepare and submit responsive tenders. Unless already provided in the notice of intended procurement, such documentation shall include a complete description of:</td>
      </tr>
       <tr>
         <td>X:7(a)</td>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -281,8 +281,10 @@ This requires the [Communication](https://github.com/open-contracting-extensions
         <td markdown=1>
 
 * Set `tender/submissionMethod` to 'electronicSubmission'
-* Enter *authentication and encryption requirements or other requirements related to the submission of information by electronic means* in `tender/submissionMethodDetails`
+* Enter or append *authentication and encryption requirements or other requirements related to the submission of information by electronic means* in `tender/submissionMethodDetails`)
+* If the electronic communication with the procuring entity requires the use of tools and devices that are not generally available, enter the Web address of these tools in `tender.communication.atypicalToolUrl`
 
+This requires the [Communication](https://github.com/open-contracting-extensions/ocds_communication_extension) extension.
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -205,7 +205,9 @@ The information included in the notice of intended procurement covers all the in
 * Add 'planning' to the `tag` array
 * Set `tender/status` to 'planning'
 * Enter *the subject-matter of the procurement* in `tender/description`. The value of `tender/description` can be updated when the data described in article VII:2(b) is published.
-* Enter *the planned date of the publication of the notice of intended procurement* in `tender/tenderPeriod/startDate`
+* Enter *the planned date of the publication of the notice of intended procurement* in `tender/communication/futureNoticeDate`
+
+This requires the [Communication](https://github.com/open-contracting-extensions/ocds_communication_extension) extension.
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -285,7 +285,7 @@ This requires the [Communication](https://github.com/open-contracting-extensions
         <td markdown=1>
 
 * Set `tender/submissionMethod` to 'electronicSubmission'
-* Enter or append *authentication and encryption requirements or other requirements related to the submission of information by electronic means* in `tender/submissionMethodDetails`)
+* Enter or append *authentication and encryption requirements or other requirements related to the submission of information by electronic means* in `tender/submissionMethodDetails`
 * If the electronic communication with the procuring entity requires the use of tools and devices that are not generally available, enter the Web address of these tools in `tender.communication.atypicalToolUrl`
 
 This requires the [Communication](https://github.com/open-contracting-extensions/ocds_communication_extension) extension.

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -183,7 +183,7 @@ This requires the [Covered By](https://github.com/open-contracting-extensions/oc
         the address from which documents relating to the procurement may be requested.</td>
         <td markdown=1>
 
-The information included in the notice of intended procurement covers all the information that must be included in a summary notice. If you follow the guidance for article VII:2, you can discard article VII:3.
+* The information included in the notice of intended procurement covers all the information that must be included in a summary notice. If you follow the guidance for article VII:2, you can discard article VII:3.
 
 </td>
       </tr>
@@ -193,7 +193,7 @@ The information included in the notice of intended procurement covers all the in
         <td markdown=1>
 
 * Enter *the subject-matter of the procurement* in `planning/rationale`
-* Enter *the planned date of the publication of the notice of intended procurement* in `tender.tenderPeriod.startDate`
+* Enter *the planned date of the publication of the notice of intended procurement* in `tender/tenderPeriod/startDate`
 </td>
       </tr>
       <tr>
@@ -201,7 +201,7 @@ The information included in the notice of intended procurement covers all the in
         <td>A procuring entity covered under Annex 2 or 3 may use a notice of planned procurement as a notice of intended procurement provided that the notice of planned procurement includes as much of the information referred to in paragraph 2 as is available to the entity and a statement that interested suppliers should express their interest in the procurement to the procuring entity.</td>
         <td markdown=1>
 
-If at the time of publishing a notice of planned procurement (article VII:4) you have all the necessary information to publish a notice of intended procurement (VII:2), follow the guidance for article VII:2 instead of the guidance for article VII:4.
+* If at the time of publishing a notice of planned procurement (article VII:4) you have all the necessary information to publish a notice of intended procurement (VII:2), follow the guidance for article VII:2, instead of the guidance for article VII:4.
 </td>
       </tr>
     </tbody>
@@ -252,7 +252,11 @@ This requires the [Award Criteria](https://github.com/open-contracting-extension
 </td>
         <td markdown=1>
 
-* 
+* Create a new OCDS release and follow the corresponding guidance, depending on the information that has been modified:
+  * If the *the criteria or requirements* are modified, follow the guidance for article X:9
+  * If *a notice* (of intended procurement) is amended or reissued, follow the guidance of article VII:2
+  * If the *tender documentation* is amended or reissued, follow the guidance for article X:7
+
 </td>
       </tr>
     </tbody>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -187,13 +187,13 @@ The information included in the notice of intended procurement covers all the in
 
 </td>
       </tr>
-<!--
       <tr>
         <td>VII:4</td>
         <td>Procuring entities are encouraged to publish in the appropriate paper or electronic medium listed in Appendix III as early as possible in each fiscal year a notice regarding their future procurement plans (hereinafter referred to as "notice of planned procurement"). The notice of planned procurement should include the subject-matter of the procurement and the planned date of the publication of the notice of intended procurement.</td>
         <td markdown=1>
 
-* 
+* Enter *the subject-matter of the procurement* in `planning/rationale`
+* Enter *the planned date of the publication of the notice of intended procurement* in `tender.tenderPeriod.startDate`
 </td>
       </tr>
       <tr>
@@ -201,11 +201,10 @@ The information included in the notice of intended procurement covers all the in
         <td>A procuring entity covered under Annex 2 or 3 may use a notice of planned procurement as a notice of intended procurement provided that the notice of planned procurement includes as much of the information referred to in paragraph 2 as is available to the entity and a statement that interested suppliers should express their interest in the procurement to the procuring entity.</td>
         <td markdown=1>
 
-* 
+If at the time of publishing a notice of planned procurement (article VII:4) you have all the necessary information to publish a notice of intended procurement (VII:2), follow the guidance for article VII:2 instead of the guidance for article VII:4.
 </td>
       </tr>
     </tbody>
--->
   </table>
 
 <!--

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -175,31 +175,16 @@ This requires the [Covered By](https://github.com/open-contracting-extensions/oc
         <td colspan="2">For each case of intended procurement, a procuring entity shall publish a summary notice that is readily accessible, at the same time as the publication of the notice of intended procurement, in one of the WTO languages.  The summary notice shall contain at least the following information:</td>
       </tr>
       <tr>
-        <td>VII:3(a)</td>
-        <td>the subject-matter of the procurement;</td>
+        <td>VII:3(a)<br/>
+        VII:3(b)<br/>
+        VII:3(c)<br/></td>
+        <td>the subject-matter of the procurement;<br/>
+        the final date for the submission of tenders or, where applicable, any final date for the submission of    requests for participation in the procurement or for inclusion on a multi-use list; and<br/>
+        the address from which documents relating to the procurement may be requested.</td>
         <td markdown=1>
 
-* Enter this in `tender/description`
-* If `tender/description` is not empty, add this to the existing content
-</td>
-      </tr>
-      <tr>
-        <td>VII:3(b)</td>
-        <td>the final date for the submission of tenders or, where applicable, any final date for the submission of requests for participation in the procurement or for inclusion on a multi-use list; and</td>
-        <td markdown=1>
+The information included in the notice of intended procurement covers all the information that must be included in a summary notice. If you follow the guidance for article VII:2, you can discard article VII:3.
 
-* Enter *the final date for the submission of tenders* or, if disclosed, *any final date for the submission of  requests for participation in the procurement or for inclusion on a multi-use list*, in `tender/tenderPeriod/endDate`
-</td>
-      </tr>
-      <tr>
-        <td>VII:3(c)</td>
-        <td>the address from which documents relating to the procurement may be requested.</td>
-        <td markdown=1>
-
-* If the address has been entered in Article VII:2(a), discard
-* Else, follow the guidance for Article VII:2(a)
-
-If possible, enter the URL, type, description and other properties of *documents relating to the procurement* in `tender/documents`.
 </td>
       </tr>
 <!--

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -214,6 +214,10 @@ The information included in the notice of intended procurement covers all the in
 * Enter *the planned date of the publication of the notice of intended procurement* in `tender/communication/futureNoticeDate`
 
 This requires the [Communication](https://github.com/open-contracting-extensions/ocds_communication_extension) extension.
+
+* If *notice regarding their future procurement plans* is also published as a document:
+ * Add a `Document` object to the `tender/documents` array
+ * Set its `documentType` to 'plannedProcurementNotice'
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -314,6 +314,8 @@ This requires the [Bid Opening](https://github.com/open-contracting-extensions/o
 This requires the [Participation Fees](https://github.com/open-contracting-extensions/ocds_participationFees_extension) extension.
 
 * Enter *the means by which tenders may be submitted* in `tender/submissionMethod`
+  * If it's on *paper*, enter 'written'
+  * If it's 'electronic', enter 'electronicSubmission'
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -227,9 +227,8 @@ If at the time of publishing a notice of planned procurement (article VII:4) you
         <td>A procuring entity shall make available to suppliers tender documentation that includes all information necessary to permit suppliers to prepare and submit responsive tenders. Unless already provided in the notice of intended procurement, such documentation shall include a complete description of:</td>
         <td markdown=1>
 
-If at the time of publishing tender documentation (article X:7) you have already published all the information necessary for a notice of intended procurement (article VII:2), and this information has not changed, discard this article.
-
-If you haven't published all the information necessary for a notice of intended procurement or if the information has changed, follow the guidance for article VII:2 to publish the new and updated data.
+* If at the time of publishing tender documentation (article X:7) you have already published all the information necessary for a notice of intended procurement (article VII:2), and this information has not changed, discard this article.
+* If you haven't published all the information necessary for a notice of intended procurement or if the information has changed, follow the guidance for article VII:2 to publish the new and updated data.
         </td>
       </tr>
       <tr>
@@ -237,7 +236,11 @@ If you haven't published all the information necessary for a notice of intended 
         <td>The evaluation criteria set out in the notice of intended procurement or tender documentation may include, among others, price and other cost factors, quality, technical merit, environmental characteristics and terms of delivery</td>
         <td markdown=1>
 
-* 
+* Enter the *evaluation criteria set out in the notice of intended procurement or tender documentation* in `tender/awardCriteria/description`, or, if possible, split this into `AwardCriterion` objects in the `tender/awardCriteria/criteria` array.
+
+This requires the [Award Criteria](https://github.com/open-contracting-extensions/ocds_awardCriteria_extension) extension.
+
+
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -201,7 +201,7 @@ The information included in the notice of intended procurement covers all the in
 
 * Add 'planning' to the `tag` array
 * Set `tender/status` to 'planning'
-* Enter *the subject-matter of the procurement* in `tender/description`
+* Enter *the subject-matter of the procurement* in `tender/description`. The value of `tender/description` can be updated when the data described in article VII:2(b) is published.
 * Enter *the planned date of the publication of the notice of intended procurement* in `tender/tenderPeriod/startDate`
 </td>
       </tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -170,6 +170,10 @@ This requires the [Second Stage](https://github.com/open-contracting-extensions/
 * Add *the criteria that will be used to select [the suppliers]* to `tender.selectionCriteria.description` or, if possible, split this into `SelectionCriterion` objects in the `tender/selectionCriteria/criteria` array.
 
 This requires the [Selection Criteria](https://github.com/open-contracting-extensions/ocds_selectionCriteria_extension) extension.
+
+* If *the criteria that will be used to select them* are published as documents:
+  * For each document, add a `Document` object to the `tender/documents` array
+  * Set its `documentType` to 'evaluationCriteria'
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -211,7 +211,9 @@ The information included in the notice of intended procurement covers all the in
 * Add 'planning' to the `tag` array
 * Set `tender/status` to 'planning'
 * Enter *the subject-matter of the procurement* in `tender/description`. The value of `tender/description` can be updated when the data described in article VII:2(b) is published.
-* Enter *the planned date of the publication of the notice of intended procurement* in `tender/tenderPeriod/startDate`
+* Enter *the planned date of the publication of the notice of intended procurement* in `tender/communication/futureNoticeDate`
+
+This requires the [Communication](https://github.com/open-contracting-extensions/ocds_communication_extension) extension.
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -254,7 +254,7 @@ This requires the [Communication](https://github.com/open-contracting-extensions
         <td>any conditions for participation of suppliers, including a list of information and documents that suppliers are required to submit in connection with the conditions for participation;</td>
         <td markdown=1>
 
-* Please follow the guidance for VII:(j)
+* Please follow the guidance for VII:2(j)
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -323,9 +323,9 @@ This requires the [Bid Opening](https://github.com/open-contracting-extensions/o
 
 This requires the [Participation Fees](https://github.com/open-contracting-extensions/ocds_participationFees_extension) extension.
 
-* Enter *the means by which tenders may be submitted* in `tender/submissionMethod`
-  * If it's on *paper*, enter 'written'
-  * If it's *electronic*, enter 'electronicSubmission'
+* Enter *the means by which tenders may be submitted* in `tender/submissionMethod`:
+  * If it's *on paper*, enter 'written'
+  * If it's *by electronic means*, enter 'electronicSubmission'
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -173,7 +173,7 @@ This requires the [Selection Criteria](https://github.com/open-contracting-exten
 
 * If *the criteria that will be used to select them* are published as documents:
   * For each document, add a `Document` object to the `tender/documents` array
-  * Set its `documentType` to 'evaluationCriteria'
+  * Set its `documentType` to 'selectionCriteria'
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -199,7 +199,9 @@ The information included in the notice of intended procurement covers all the in
         <td>Procuring entities are encouraged to publish in the appropriate paper or electronic medium listed in Appendix III as early as possible in each fiscal year a notice regarding their future procurement plans (hereinafter referred to as "notice of planned procurement"). The notice of planned procurement should include the subject-matter of the procurement and the planned date of the publication of the notice of intended procurement.</td>
         <td markdown=1>
 
-* Enter *the subject-matter of the procurement* in `planning/rationale`
+* Add 'planning' to the `tag` array
+* Set `tender/status` to 'planning'
+* Enter *the subject-matter of the procurement* in `tender/description`
 * Enter *the planned date of the publication of the notice of intended procurement* in `tender/tenderPeriod/startDate`
 </td>
       </tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -276,7 +276,8 @@ This requires the [Communication](https://github.com/open-contracting-extensions
         <td>all evaluation criteria the entity will apply in the awarding of the contract, and, except where price is the sole criterion, the relative importance of such criteria;</td>
         <td markdown=1>
 
-* Follow the guidance for VII:2(k)
+* Map *all evaluation criteria the entity will apply in the awarding of the contract* and *the relative importance of such criteria* to `tender.awardCriteriaDetails`
+* If *price is the sole criterion*, set `tender.awardCriteria` to 'priceOnly'
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -260,7 +260,7 @@ This requires the [Communication](https://github.com/open-contracting-extensions
         <td>any conditions for participation of suppliers, including a list of information and documents that suppliers are required to submit in connection with the conditions for participation;</td>
         <td markdown=1>
 
-* Please follow the guidance for VII:(j)
+* Please follow the guidance for VII:2(j)
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -236,12 +236,85 @@ The information included in the notice of intended procurement covers all the in
     <tbody>
       <tr class="section">
         <td>X:7</td>
-        <td>A procuring entity shall make available to suppliers tender documentation that includes all information necessary to permit suppliers to prepare and submit responsive tenders. Unless already provided in the notice of intended procurement, such documentation shall include a complete description of:</td>
+        <td colspan=2>A procuring entity shall make available to suppliers tender documentation that includes all information necessary to permit suppliers to prepare and submit responsive tenders. Unless already provided in the notice of intended procurement, such documentation shall include a complete description of:</td>
+     </tr>
+      <tr>
+        <td>X:7(a)</td>
+        <td>the procurement, including the nature and the quantity of the goods or services to be procured or, where the quantity is not known, the estimated quantity and any requirements to be fulfilled, including any technical specifications, conformity assessment certification, plans, drawings or instructional materials;</td>
         <td markdown=1>
 
-* If at the time of publishing tender documentation (article X:7) you have already published all the information necessary for a notice of intended procurement (article VII:2), and this information has not changed, discard this article.
-* If you haven't published all the information necessary for a notice of intended procurement or if the information has changed, follow the guidance for article VII:2 to publish the new and updated data.
-        </td>
+* For *the procurement, including the nature and the quantity of the goods or services to be procured or, where the quantity is not known, the estimated quantity*, follow the guidance for article VII:2(b)
+* For *any requirements to be fulfilled, including any technical specifications, conformity assessment certification, plans, drawings or instructional materials*, follow the guidance for article VII:2(j)
+</td>
+      </tr>
+      <tr>
+        <td>X:7(b)</td>
+        <td>any conditions for participation of suppliers, including a list of information and documents that suppliers are required to submit in connection with the conditions for participation;</td>
+        <td markdown=1>
+
+* Please follow the guidance for VII:(j)
+</td>
+      </tr>
+      <tr>
+        <td>X:7(c)</td>
+        <td>all evaluation criteria the entity will apply in the awarding of the contract, and, except where price is the sole criterion, the relative importance of such criteria;</td>
+        <td markdown=1>
+
+* Please follow the guidance for VII:(k)
+</td>
+      </tr>
+      <tr>
+        <td>X:7(d)</td>
+        <td>where the procuring entity will conduct the procurement by electronic means, any authentication and encryption requirements or other requirements related to the submission of information by electronic means;</td>
+        <td markdown=1>
+
+* Set `tender/submissionMethod` to 'electronicSubmission'
+* Enter *authentication and encryption requirements or other requirements related to the submission of information by electronic means* in `tender/submissionMethodDetails`
+
+</td>
+      </tr>
+      <tr>
+        <td>X:7(e)</td>
+        <td>where the procuring entity will hold an electronic auction, the rules, including identification of the elements of the tender related to the evaluation criteria, on which the auction will be conducted;</td>
+        <td markdown=1>
+
+* Set `tender/techniques/hasElectronicAuction` to `true`
+* Enter *the rules, including identification of the elements of the tender related to the evaluation criteria, on which the auction will be conducted* in `tender/techniques/electronicAuction/description`
+
+This requires the [Techniques](https://github.com/open-contracting-extensions/ocds_techniques_extension) extension.
+</td>
+      </tr>
+      <tr>
+        <td>X:7(f)</td>
+        <td>where there will be a public opening of tenders, the date, time and place for the opening and, where appropriate, the persons authorized to be present;</td>
+        <td markdown=1>
+
+* Enter the *date* and the *time* in `tender/bidOpening/date`
+* Enter the *place* in `tender/bidOpening/address`, `tender/bidOpening/location` or `tender/bidOpening/gazetteer`
+* Enter *the persons authorized to be present* in `tender/bidOpening/description`
+
+This requires the [Bid Opening](https://github.com/open-contracting-extensions/ocds_bidOpening_extension) extension.
+</td>
+      </tr>
+      <tr>
+        <td>X:7(g)</td>
+        <td>any other terms or conditions, including terms of payment and any limitation on the means by which tenders may be submitted, such as whether on paper or by electronic means; and</td>
+        <td markdown=1>
+
+* Enter the *terms of payment* in `tender/participationFees`
+
+This requires the [Participation Fees](https://github.com/open-contracting-extensions/ocds_participationFees_extension) extension.
+
+* Enter *the means by which tenders may be submitted* in `tender/submissionMethod`
+</td>
+      </tr>
+      <tr>
+        <td>X:7(h)</td>
+        <td>any dates for the delivery of goods or the supply of services</td>
+        <td markdown=1>
+
+* Please follow the guidance for article VII:2(e)
+</td>
       </tr>
       <tr>
         <td>X:9</td>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -321,11 +321,7 @@ This requires the [Participation Fees](https://github.com/open-contracting-exten
         <td>The evaluation criteria set out in the notice of intended procurement or tender documentation may include, among others, price and other cost factors, quality, technical merit, environmental characteristics and terms of delivery</td>
         <td markdown=1>
 
-* Enter the *evaluation criteria set out in the notice of intended procurement or tender documentation* in `tender/awardCriteria/description`, or, if possible, split this into `AwardCriterion` objects in the `tender/awardCriteria/criteria` array.
-
-This requires the [Award Criteria](https://github.com/open-contracting-extensions/ocds_awardCriteria_extension) extension.
-
-
+* Enter the *evaluation criteria set out in the notice of intended procurement or tender documentation* in `tender/awardCriteriaDetails`
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -229,7 +229,7 @@ This requires the [Communication](https://github.com/open-contracting-extensions
         <td>A procuring entity covered under Annex 2 or 3 may use a notice of planned procurement as a notice of intended procurement provided that the notice of planned procurement includes as much of the information referred to in paragraph 2 as is available to the entity and a statement that interested suppliers should express their interest in the procurement to the procuring entity.</td>
         <td markdown=1>
 
-* Please follow the guidance for article VII:2.
+* Follow the guidance for article VII:2.
 </td>
       </tr>
     </tbody>
@@ -268,7 +268,7 @@ This requires the [Communication](https://github.com/open-contracting-extensions
         <td>any conditions for participation of suppliers, including a list of information and documents that suppliers are required to submit in connection with the conditions for participation;</td>
         <td markdown=1>
 
-* Please follow the guidance for VII:2(j)
+* Follow the guidance for VII:2(j)
 </td>
       </tr>
       <tr>
@@ -276,7 +276,7 @@ This requires the [Communication](https://github.com/open-contracting-extensions
         <td>all evaluation criteria the entity will apply in the awarding of the contract, and, except where price is the sole criterion, the relative importance of such criteria;</td>
         <td markdown=1>
 
-* Please follow the guidance for VII:(k)
+* Follow the guidance for VII:(k)
 </td>
       </tr>
       <tr>
@@ -333,7 +333,7 @@ This requires the [Participation Fees](https://github.com/open-contracting-exten
         <td>any dates for the delivery of goods or the supply of services</td>
         <td markdown=1>
 
-* Please follow the guidance for article VII:2(e)
+* Follow the guidance for article VII:2(e)
 </td>
       </tr>
       <tr>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -1,3 +1,4 @@
+
 # Annotated Revised GPA
 
 ```eval_rst
@@ -156,6 +157,7 @@ This requires the [Additional Contact Points](https://github.com/open-contractin
 * If *requirements are included in tender documentation that is made available to all interested suppliers*:
   * For each document, add a `Document` object to the `tender/documents` array
   * Set its `documentType` to 'eligibilityCriteria'
+  * Fill any other known information for the document ([`Document` object schema](https://standard.open-contracting.org/1.1/en/schema/reference/#document))
 </td>
       </tr>
       <tr>
@@ -174,6 +176,8 @@ This requires the [Selection Criteria](https://github.com/open-contracting-exten
 * If *the criteria that will be used to select them* are published as documents:
   * For each document, add a `Document` object to the `tender/documents` array
   * Set its `documentType` to 'selectionCriteria'
+  * Fill any other known information for the document ([`Document` object schema](https://standard.open-contracting.org/1.1/en/schema/reference/#document))
+
 </td>
       </tr>
       <tr>
@@ -218,6 +222,8 @@ This requires the [Communication](https://github.com/open-contracting-extensions
 * If *notice regarding their future procurement plans* is also published as a document:
  * Add a `Document` object to the `tender/documents` array
  * Set its `documentType` to 'plannedProcurementNotice'
+ * Fill any other known information for the document ([`Document` object schema](https://standard.open-contracting.org/1.1/en/schema/reference/#document))
+
 </td>
       </tr>
       <tr>
@@ -341,7 +347,7 @@ This requires the [Participation Fees](https://github.com/open-contracting-exten
 * If the *evaluation criteria* are published as a document:
  * Add a `Document` object to the `tender/documents` array
  * Set its `documentType` to 'evaluationCriteria'
-
+ * Fill any other known information for the document ([`Document` object schema](https://standard.open-contracting. org/1.1/en/schema/reference/#document))
 </td>
       </tr>
       <tr>
@@ -394,7 +400,7 @@ This requires the [Participation Fees](https://github.com/open-contracting-exten
 * If the *report in writing* is also published as a document
   * Add a `Document` object to the `tender/documents` array
   * Set its `documentType` to 'awardNotice'
-
+  * Fill any other known information for the document ([`Document` object schema](https://standard.open-contracting. org/1.1/en/schema/reference/#document))
 </td>
       </tr>
     </tbody>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -231,7 +231,7 @@ This requires the [Communication](https://github.com/open-contracting-extensions
         <td>A procuring entity covered under Annex 2 or 3 may use a notice of planned procurement as a notice of intended procurement provided that the notice of planned procurement includes as much of the information referred to in paragraph 2 as is available to the entity and a statement that interested suppliers should express their interest in the procurement to the procuring entity.</td>
         <td markdown=1>
 
-* Please follow the guidance for article VII:3.
+* Please follow the guidance for article VII:2.
 </td>
       </tr>
     </tbody>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -110,9 +110,7 @@ The addition of `period` to the `Milestone` building block is [under discussion]
 
 * Use 'open', 'selective' or 'limited' for *the procurement method that will be used* in `tender/procurementMethod`
 * If *it will involve negotiation*, add "negotiated" to `tender/procurementMethodDetails`
-* If *it will involve electronic auction*
-  * set `tender/submissionMethod` to `electronicAuction`
-  * set `tender/techniques/hasElectronicAuction` to `true`
+* If *it will involve electronic auction*, set `tender/techniques/hasElectronicAuction` to `true`
 
 This requires the [Techniques](https://github.com/open-contracting-extensions/ocds_techniques_extension) extension.
 </td>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -213,7 +213,7 @@ The information included in the notice of intended procurement covers all the in
         <td>A procuring entity covered under Annex 2 or 3 may use a notice of planned procurement as a notice of intended procurement provided that the notice of planned procurement includes as much of the information referred to in paragraph 2 as is available to the entity and a statement that interested suppliers should express their interest in the procurement to the procuring entity.</td>
         <td markdown=1>
 
-* If at the time of publishing a notice of planned procurement (article VII:4) you have all the necessary information to publish a notice of intended procurement (VII:2), follow the guidance for article VII:2, instead of the guidance for article VII:4.
+* Please follow the guidance for article VII:3.
 </td>
       </tr>
     </tbody>

--- a/docs/gpa.md
+++ b/docs/gpa.md
@@ -11,7 +11,7 @@ This document annotates selected parts of the GPA, with details on how to publis
 ```eval_rst
 .. warning::
 
-   References from Articles VII:4, VII:5, IX:8, IX:9, X:7, X:9, X:11, XIII:2, XIV:1, XVI:2 are not yet added.
+   References from Articles IX:8, IX:9, X:7, X:9, X:11, XIII:2, XIV:1, XVI:2 are not yet added.
 ```
 
 <div class="wy-table-responsive">


### PR DESCRIPTION
(includes commits from VII:3)

I'm not happy with the mapping of the date publication of the notice of intended procurement, in VII:4. I think a `Milestone` would have been more suitable, but I found no suitable [milestone type code](https://standard.open-contracting.org/latest/en/schema/codelists/#milestone-type).

In the EU profile we used `tender.communication.futureNoticeDate`. This property was created for the context of the TED forms, so the semantics might a bit loose for the GPA context. What do you think?